### PR TITLE
Fix pin assignments for atreus_split_v2/featherble

### DIFF
--- a/keyboards/atreus_split_v2/featherble/config.h
+++ b/keyboards/atreus_split_v2/featherble/config.h
@@ -20,7 +20,7 @@
 
 // Feather BLE Row & Column Pins
 #define MATRIX_ROW_PINS { F7, F6, F5, F4 }
-#define MATRIX_COL_PINS { F1, D6, B7, B6, B5, D7 }
+#define MATRIX_COL_PINS { F1, D6, B7, B6, D7, C6 }
 
 #define UNUSED_PINS
 


### PR DESCRIPTION
For some reason, we defined some of the MATRIX_COL_PINS incorrectly. I updated the values to match our spreadsheet[1] and physical connections to fix the featherble model.

[1]https://docs.google.com/spreadsheets/d/111L60Sdy7iIqxGysrV9EoDLEPS2vHcziu_CG3vSjve8/edit#gid=1986656799